### PR TITLE
Initial development

### DIFF
--- a/.github/workflows/test_and_lint.yml
+++ b/.github/workflows/test_and_lint.yml
@@ -21,6 +21,6 @@ jobs:
       run: | 
         python -m pip install -e .[dev]
     - name: Run linter checks
-      run: flake8 . && interrogate --verbose .
+      run: flake8 . --ignore=E501,C901 && interrogate --verbose .
     - name: Run tests and coverage
       run: coverage run -m unittest discover && coverage report

--- a/.github/workflows/test_and_lint.yml
+++ b/.github/workflows/test_and_lint.yml
@@ -21,6 +21,6 @@ jobs:
       run: | 
         python -m pip install -e .[dev]
     - name: Run linter checks
-      run: flake8 . --ignore=E501,C901 && interrogate --verbose .
+      run: flake8 . --ignore=E501,C901,W503 && interrogate --verbose .
     - name: Run tests and coverage
       run: coverage run -m unittest discover && coverage report

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .ipynb_checkpoints
 test.ipynb
+recon_io_test.ipynb
+src/aind_neuron_reconstruction_io/util_files/*
+!src/aind_neuron_reconstruction_io/util_files/*.nrrd
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.ipynb_checkpoints
+test.ipynb
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/doc_template/source/conf.py
+++ b/doc_template/source/conf.py
@@ -1,12 +1,15 @@
 """Configuration file for the Sphinx documentation builder."""
+
 #
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-# -- Path Setup --------------------------------------------------------------
-from os.path import dirname, abspath
-from pathlib import Path
 from datetime import date
+
+# -- Path Setup --------------------------------------------------------------
+from os.path import abspath, dirname
+from pathlib import Path
+
 from aind_neuron_reconstruction_io import __version__ as package_version
 
 INSTITUTE_NAME = "Allen Institute for Neural Dynamics"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+boto3==1.17.21
+botocore==1.20.112
+cloud_volume==8.33.0
+numpy==1.23.5
+pandas==1.5.3
+protobuf==5.27.1
+pynrrd==0.4.3
+setuptools==65.6.3
+six==1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ protobuf==5.27.1
 pynrrd==0.4.3
 setuptools==65.6.3
 six==1.16.0
+meshparty==1.16.14

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,33 @@
-from setuptools import setup
+from setuptools import setup, find_packages
+import os
+
+
+def read(rel_path: str) -> str:
+    here = os.path.abspath(os.path.dirname(__file__))
+    print(here)
+    with open(os.path.join(here, rel_path)) as fp:
+        return fp.read()
+
+
+def get_version(rel_path: str) -> str:
+    for line in read(rel_path).splitlines():
+        if line.startswith("__version__"):
+            delim = '"' if '"' in line else "'"
+            return line.split(delim)[1]
+    raise RuntimeError("Unable to find version string.")
+
+
+with open('requirements.txt', 'r') as f:
+    required = f.read().splitlines()
 
 if __name__ == "__main__":
-    setup()
+    setup(
+        name="aind-neuron-reconstruction-io",
+        version=get_version("src/aind_neuron_reconstruction_io/__init__.py"),
+        author='Matt Mallory, Sharmishtaa Seshamani',
+        author_email="matt.mallory@alleninstitute.org, sharmishtaas@alleninstitute.org",
+        packages=find_packages(),
+        install_requires=required,
+        package_data={"src": ["aind_neuron_reconstruction_io/util_files/*.nrrd"]},
+        include_package_data=True,
+    )

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
-from setuptools import setup, find_packages
 import os
+
+from setuptools import find_packages, setup
 
 
 def read(rel_path: str) -> str:
@@ -17,17 +18,19 @@ def get_version(rel_path: str) -> str:
     raise RuntimeError("Unable to find version string.")
 
 
-with open('requirements.txt', 'r') as f:
+with open("requirements.txt", "r") as f:
     required = f.read().splitlines()
 
 if __name__ == "__main__":
     setup(
         name="aind-neuron-reconstruction-io",
         version=get_version("src/aind_neuron_reconstruction_io/__init__.py"),
-        author='Matt Mallory, Sharmishtaa Seshamani',
+        author="Matt Mallory, Sharmishtaa Seshamani",
         author_email="matt.mallory@alleninstitute.org, sharmishtaas@alleninstitute.org",
         packages=find_packages(),
         install_requires=required,
-        package_data={"src": ["aind_neuron_reconstruction_io/util_files/*.nrrd"]},
+        package_data={
+            "src": ["aind_neuron_reconstruction_io/util_files/*.nrrd"]
+        },
         include_package_data=True,
     )

--- a/src/aind_neuron_reconstruction_io/NeuronData.py
+++ b/src/aind_neuron_reconstruction_io/NeuronData.py
@@ -1,0 +1,346 @@
+import json
+import numpy as np
+import cloudvolume
+import pandas as pd
+from aind_neuron_reconstruction_io import io
+from aind_neuron_reconstruction_io.utils import (fix_local_cloudpath, file_exists,
+                                                     get_parent_dir, get_grandparent_dir, 
+                                                     get_basename, get_file_extension, 
+                                                     create_directory, read_file)
+
+class NeuronData(pd.DataFrame):
+    
+    _metadata = ['path_to_file', 'project_directory', 'neuron_id', '_child_ids_dict']
+    
+    @property
+    def _constructor(self):
+        return NeuronData
+
+    @property
+    def _constructor_sliced(self):
+        return pd.Series  
+    
+    def __init__(self, path_to_file, *args, **kwargs):
+        if isinstance(path_to_file, str):
+            self.project_directory = None # for loading neuroglancer precomputed
+            self.neuron_id = None # for loading neuroglancer precomputed
+            self.path_to_file = path_to_file
+            self.validate_file()
+            data = self.load_data()
+            super().__init__(data, *args, **kwargs)
+        else:
+            super().__init__(path_to_file, *args, **kwargs)
+        
+
+    def validate_file(self):
+        "Validate input file"
+        
+        # Check file extension
+        file_extension = get_file_extension(self.path_to_file)
+        
+        if file_extension not in ['.swc', '.json', '']:
+            raise ValueError("File must be a .swc, .json, or an extensionless precomputed file")
+        
+        # Additional checks based on content
+        if file_extension == '.json':
+            self.validate_json()
+        elif file_extension == '.swc':
+            self.validate_swc()
+        else:
+            self.validate_precomputed()
+
+
+    def validate_json(self):
+        """
+        Will verify:
+        1) the data can be loaded with json
+        2) there exists neuron data
+        1) the soma is present and it has all required data
+        2) if there are axon or dendrite nodes present that they have at least one root node
+            pointing it back to the soma.
+        """
+
+        try:
+            file_content = read_file(self.path_to_file)
+            data = json.loads(file_content)
+            # Add your JSON validation logic here using json_data
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Invalid JSON file: {e}")
+        except Exception as e:
+            raise ValueError(f"Error reading JSON file: {e}")
+
+        if "neurons" not in data:
+            raise ValueError("input json must have 'neurons' key")
+        
+        neuron_dicts = data['neurons']
+        if neuron_dicts == []:
+            raise ValueError("at least one neuron must be contained within the 'neurons' value")
+
+        if len(neuron_dicts) != 1:
+            raise ValueError(f"Each mouselight .json file should contain 1 neuron but {len(neuron_dicts)} were found")
+
+    
+        for neuron_dictionary in neuron_dicts:  
+            if "soma" not in neuron_dictionary:
+                raise ValueError("No soma node detected in the input neuron ") 
+            if not all([key in neuron_dictionary['soma'] for key in ['x','y','z']]):
+                raise ValueError("'x', 'y' and 'z' are required for the soma node")
+            
+            for compartment in ['axon', 'dendrite']:
+
+                if compartment in neuron_dictionary:
+                    these_nodes = neuron_dictionary[compartment]
+                    if these_nodes:
+                        roots = [n for n in these_nodes if n['parentNumber']==-1]
+                        if roots == []:
+                            raise ValueError(f"{compartment} compartment does not have a root node (i.e. a node with parent = -1) ") 
+              
+                            
+    def validate_swc(self):
+        try:
+            file_content = read_file(self.path_to_file)
+            lines = file_content.splitlines()
+        except Exception as e:
+            err_msg = f"Invalid SWC file: {self.path_to_file}"
+            raise ValueError(err_msg) from e
+
+
+    def validate_precomputed(self):
+        """
+        Requires:
+        1) the precomputed file exists
+        2) The neuroglancer files should be formatted as follows:
+        
+            project_directory 
+                info
+                skeleton
+                    1324
+                    1422
+                    1950
+                    info
+        3) that the precomputed file passed into NeuronData is an integer (e.g. 1324)
+        """
+        if not file_exists(self.path_to_file):
+            raise ValueError(f"Provided input file does not exists:\n{self.path_to_file}")
+
+        # the info file should be one directory up from the provided path
+        project_dir = get_grandparent_dir(self.path_to_file)
+        project_info_file = f"{project_dir}/info"
+        if not file_exists(project_info_file):
+            raise ValueError(f"neuroglancer info file not found. Expected one at the following path:\n{project_info_file}")        
+        self.project_directory = project_dir
+        
+        neuron_id = get_basename(self.path_to_file)
+        try:
+            neuron_id = int(neuron_id)
+            
+        except ValueError as e:
+            err_msg = f"Could not interpret precomputed neuron id as integer.\nInput file:\n {self.path_to_file}\n Derived neuron id: {neuron_id}"
+            raise ValueError(err_msg) from e
+        
+        
+        self.neuron_id = neuron_id
+        
+        
+    def load_data(self):
+        
+        # Load data based on file type
+        file_extension = get_file_extension(self.path_to_file)
+        if file_extension == '.json':
+            neuron_df =  io.read_json(self.path_to_file)
+        elif file_extension == '.swc':
+            neuron_df = io.read_swc(self.path_to_file)
+        else:
+            neuron_df = io.read_precomputed(self.project_directory, self.neuron_id)
+
+        # this computation is useful if we want to add things like NeuronData.get_children(node_id)
+        parent_ids_dict = dict(zip(neuron_df["node_id"],neuron_df["parent"]))
+        child_ids_dict = { nid:[] for nid in parent_ids_dict }
+        for nid in parent_ids_dict:
+            pid = parent_ids_dict[nid]
+            if pid != -1:
+                child_ids_dict[pid].append(nid)
+        
+        # create the child look up dictionary
+        self._child_ids_dict = child_ids_dict
+        return neuron_df
+          
+               
+    def to_precomputed(self, outfile):
+        """
+        Write NeuronData to binary precomputed file for neuroglancer. This will 
+        initialize a info file for the output directory, create a skeletons directory, 
+        add an info file there and write the skeleton to a precomputed format.
+        
+        TODO add metadata
+        
+        Args:
+            outfile (str): path to output file, the file name should be the "segid" i.e.
+                           the unique neuroglancer id for this neuron (e.g. /path/to/1000)
+                           if you want the segid to be 1000
+        """
+        segid = get_basename(outfile)
+        output_dir = get_parent_dir(outfile)
+        output_dir_cp = fix_local_cloudpath(output_dir)
+
+        info = cloudvolume.CloudVolume.create_new_info(
+            num_channels    = 1,
+            mesh            = "mesh",
+            layer_type      = 'segmentation',
+            data_type       = 'uint64', # Channel images might be 'uint8'
+            # raw, png, jpeg, compressed_segmentation, fpzip, kempressed, zfpc, compresso, crackle
+            encoding        = 'raw', 
+            resolution      = [1000,1000,1000], # Voxel scaling, units are in nanometers
+            voxel_offset    = [0, 0, 0], # x,y,z offset in voxels from the origin
+            skeletons        = 'skeleton',
+            # Pick a convenient size for your underlying chunk representation
+            # Powers of two are recommended, doesn't need to cover image exactly
+            chunk_size      = [ 512,512,512], #the voxels
+            volume_size = [13200,8000,11400]
+        )
+        info['segment_properties']='segment_properties'
+        #correct location
+        cv = cloudvolume.CloudVolume(output_dir_cp , mip=0, info=info, compress=False)
+        cv.commit_info()
+        
+        sk_info = cv.skeleton.meta.default_info()
+        sk_info['transform'] = [1000, 0, 0, 0, 0, 1000, 0, 0, 0, 0, 1000, 0]
+        sk_info['vertex_attributes'] = [
+            { 'id': 'radius',
+                'data_type': 'float32',
+                'num_components': 1
+            },
+            {
+                'id': 'allenId',
+                'data_type': 'float32',
+                'num_components': 1
+            },
+            {
+                'id': 'compartment',
+                'data_type': 'float32',
+                'num_components': 1
+            }
+        ]
+        cv.skeleton.meta.info = sk_info
+        cv.skeleton.meta.commit_info()
+
+        vertices = self[['x','y','z']].values
+
+        node_id_toindex = dict(zip(self.node_id, self.index))
+        # get edges
+        edge_df = self.loc[self['parent']!=-1]
+        edge_ids = edge_df.node_id.map(node_id_toindex)
+        parent_ids = edge_df.parent.map(node_id_toindex)
+        # relabel the edges so that they are the index aligned with the vertices
+        edges_relabeled = np.column_stack((edge_ids, parent_ids))
+
+        radius = self['r'].values.astype(np.float32)
+        vertex_types = self['type'].values.astype(np.float32)
+        
+        sk_cv = cloudvolume.Skeleton(vertices,
+                                     edges_relabeled,
+                                     radius,
+                                     None, 
+                                     segid=segid,
+                                     extra_attributes = sk_info['vertex_attributes']
+                                     )
+        sk_cv.allenId = self.allenId.values
+        sk_cv.compartment = vertex_types
+        
+        cv.skeleton.upload(sk_cv)
+        
+        
+        
+def neurondata_list_to_precomputed(list_of_neuron_data, output_dir, neuron_ids = None):
+    """
+    Will write a list of NeuronData objects to an output directory with info files
+
+    Args:
+        list_of_neuron_data (list): list of NeuronData objects
+        output_dir (str): path to output neuroglancer dir
+        neuron_ids (list): list of neuron IDs (integers), if not provided will just
+        use the NeuronDatas index in the list.
+        
+    TODO: pass in metadata for skeletons 
+    """
+    if not file_exists(output_dir):
+        create_directory(output_dir)
+    
+    if neuron_ids is not None:
+        if len(neuron_ids)!=len(list_of_neuron_data):
+            raise ValueError(f"Length of neruon_ids {len(neuron_ids)} does not match length of neuron data ({len(list_of_neuron_data)})")
+    else:
+        neuron_ids = [i+1 for i in range(len(list_of_neuron_data))]
+        
+    output_dir_cp = fix_local_cloudpath(output_dir)
+
+    info = cloudvolume.CloudVolume.create_new_info(
+        num_channels    = 1,
+        mesh            = "mesh",
+        layer_type      = 'segmentation',
+        data_type       = 'uint64', # Channel images might be 'uint8'
+        # raw, png, jpeg, compressed_segmentation, fpzip, kempressed, zfpc, compresso, crackle
+        encoding        = 'raw', 
+        resolution      = [1000,1000,1000], # Voxel scaling, units are in nanometers
+        voxel_offset    = [0, 0, 0], # x,y,z offset in voxels from the origin
+        skeletons        = 'skeleton',
+        # Pick a convenient size for your underlying chunk representation
+        # Powers of two are recommended, doesn't need to cover image exactly
+        chunk_size      = [ 512,512,512], #the voxels
+        volume_size = [13200,8000,11400]
+    )
+    info['segment_properties']='segment_properties'
+    #correct location
+    cv = cloudvolume.CloudVolume(output_dir_cp , mip=0, info=info, compress=False)
+    cv.commit_info()
+    
+    sk_info = cv.skeleton.meta.default_info()
+    sk_info['transform'] = [1000, 0, 0, 0, 0, 1000, 0, 0, 0, 0, 1000, 0]
+    sk_info['vertex_attributes'] = [
+        { 'id': 'radius',
+            'data_type': 'float32',
+            'num_components': 1
+        },
+        {
+            'id': 'allenId',
+            'data_type': 'float32',
+            'num_components': 1
+        },
+        {
+            'id': 'compartment',
+            'data_type': 'float32',
+            'num_components': 1
+        }
+    ]
+    cv.skeleton.meta.info = sk_info
+    cv.skeleton.meta.commit_info()
+
+    skeletons = []
+    for neuron_data,neuron_id in zip(list_of_neuron_data,neuron_ids):
+            
+        vertices = neuron_data[['x','y','z']].values
+
+        node_id_toindex = dict(zip(neuron_data.node_id, neuron_data.index))
+        # get edges
+        edge_df = neuron_data.loc[neuron_data['parent']!=-1]
+        edge_ids = edge_df.node_id.map(node_id_toindex)
+        parent_ids = edge_df.parent.map(node_id_toindex)
+        # relabel the edges so that they are the index aligned with the vertices
+        edges_relabeled = np.column_stack((edge_ids, parent_ids))
+
+        radius = neuron_data['r'].values.astype(np.float32)
+        vertex_types = neuron_data['type'].values.astype(np.float32)
+        
+        sk_cv = cloudvolume.Skeleton(vertices,
+                                        edges_relabeled,
+                                        radius,
+                                        None, 
+                                        segid=neuron_id,
+                                        extra_attributes = sk_info['vertex_attributes']
+                                        )
+        sk_cv.allenId = neuron_data.allenId.values
+        sk_cv.compartment = vertex_types
+        
+        skeletons.append(sk_cv)
+    cv.skeleton.upload(skeletons)
+    

--- a/src/aind_neuron_reconstruction_io/NeuronData.py
+++ b/src/aind_neuron_reconstruction_io/NeuronData.py
@@ -1,166 +1,229 @@
+"""
+This module provides the NeuronData class and related utilities
+for validating, loading, and converting various neuron data formats.
+"""
+
 import json
-import numpy as np
+
 import cloudvolume
+import numpy as np
 import pandas as pd
+
 from aind_neuron_reconstruction_io import io
-from aind_neuron_reconstruction_io.utils import (fix_local_cloudpath, file_exists,
-                                                     get_parent_dir, get_grandparent_dir, 
-                                                     get_basename, get_file_extension, 
-                                                     create_directory, read_file,
-                                                     pull_mw_skel_colors)
+from aind_neuron_reconstruction_io.utils import (
+    create_directory,
+    file_exists,
+    fix_local_cloudpath,
+    get_basename,
+    get_file_extension,
+    get_grandparent_dir,
+    get_parent_dir,
+    read_file,
+)
+
 
 class NeuronData(pd.DataFrame):
-    
+    """Base class for NeuronData
+    Args:
+
+    Returns:
+        NeuronData:
+    """
+
     _metadata = [
-        'path_to_file', 
-        'input_data', 
-        'ccf_annotate_vertices', 
-        'project_directory', 
-        'neuron_id', 
-        '_child_ids_dict'
-        ]
-    
+        "path_to_file",
+        "input_data",
+        "ccf_annotate_vertices",
+        "project_directory",
+        "neuron_id",
+        # '_child_ids_dict'
+    ]
+
     @property
     def _constructor(self):
+        """constructor class"""
         return NeuronData
 
     @property
     def _constructor_sliced(self):
-        return pd.Series  
-    def __init__(self, 
-                 path_to_file: str = None, 
-                 input_data: pd.DataFrame = None, 
-                 ccf_annotate_vertices: bool = False, 
-                 *args, **kwargs
-                 ):
-        """NeuronData class. Either path_to_file or input_data should be provided, not both. 
+        """property class"""
+        return pd.Series
+
+    def __init__(
+        self,
+        path_to_file: str = None,
+        input_data: pd.DataFrame = None,
+        ccf_annotate_vertices: bool = False,
+        *args,
+        **kwargs,
+    ):
+        """NeuronData class. Either path_to_file or input_data should be provided, not both.
 
         Args:
             path_to_file (str, optional): path to a neuron file can be from the following
             sources: .swc, .json (mouselight), .h5 (meshparty), precomputed (no extension).
             Defaults to None. If None is passed for path_to_file, expects input_data to be passed.
-            
+
             input_data (pd.DataFrame, optional): when this is not None, will create a NeuronData
             object from this dataframe. Used when converting a meshworks skeleton to NeuronData.
             The dataframe must have the columns listed below. Defaults to None. Expected columns:
             x,y,z,radius,compartment,id,postsynaptic_count,presynaptic_count,allenId
-            
+
             ccf_annotate_vertices (bool, optional): when True will annotate the NeuronData vertices
             with CCF structure ID. Defaults to False.
         """
-        
+
         if (path_to_file is None) and (input_data is None):
-            raise ValueError("path_to_file and input_data are both None, need one or the other to create a NeuronData object")
+            raise ValueError(
+                "path_to_file and input_data are both None, need one or the other to create a NeuronData object"
+            )
         elif (path_to_file is not None) and (input_data is not None):
-            raise ValueError("path_to_file and input_data are both defined, need only one to create a NeuronData object")
-        
+            raise ValueError(
+                "path_to_file and input_data are both defined, need only one to create a NeuronData object"
+            )
+
         self.input_data = input_data
         self.path_to_file = path_to_file
         if isinstance(path_to_file, str):
-            self.project_directory = None # for loading neuroglancer precomputed
-            self.neuron_id = None # for loading neuroglancer precomputed
+            self.project_directory = (
+                None  # for loading neuroglancer precomputed
+            )
+            self.neuron_id = None  # for loading neuroglancer precomputed
             self.ccf_annotate_vertices = ccf_annotate_vertices
             self.validate_file()
             data = self.load_data()
-            
+
             # default values for non-em data
             if "presynaptic_count" not in data.columns:
-                data['presynaptic_count'] = [0]*len(data)
+                data["presynaptic_count"] = [0] * len(data)
             if "postsynaptic_count" not in data.columns:
-                data['postsynaptic_count'] = [0]*len(data)
-            
+                data["postsynaptic_count"] = [0] * len(data)
+
             super().__init__(data, *args, **kwargs)
-            
+
         elif self.input_data is not None:
-            # generate from input data frame 
-            self.project_directory = None # for loading neuroglancer precomputed
-            self.neuron_id = None # for loading neuroglancer precomputed
+            # generate from input data frame
+            self.project_directory = (
+                None  # for loading neuroglancer precomputed
+            )
+            self.neuron_id = None  # for loading neuroglancer precomputed
             self.ccf_annotate_vertices = ccf_annotate_vertices
             super().__init__(self.input_data, *args, **kwargs)
-            
+
         else:
             super().__init__(path_to_file, *args, **kwargs)
-        
 
     def validate_file(self):
         "Validate input file"
-        
+
         # Check file extension
         file_extension = get_file_extension(self.path_to_file)
-        
-        if file_extension not in ['.swc', '.json', '.h5', '']:
-            raise ValueError("File must be a .swc, .json, or an extensionless precomputed file")
-        
+
+        if file_extension not in [".swc", ".json", ".h5", ""]:
+            raise ValueError(
+                "File must be a .swc, .json, or an extensionless precomputed file"
+            )
+
         # Additional checks based on content
-        if file_extension == '.json':
+        if file_extension == ".json":
             self.validate_json()
-        elif file_extension == '.swc':
+        elif file_extension == ".swc":
             self.validate_swc()
         elif file_extension == ".h5":
             self.validate_h5()
         else:
             self.validate_precomputed()
 
-
     def validate_json(self):
         """
-        Will verify:
-        1) the data can be loaded with json
-        2) there exists neuron data
-        1) the soma is present and it has all required data
-        2) if there are axon or dendrite nodes present that they have at least one root node
-            pointing it back to the soma.
-        """
+        Validate a .json file containing neuron data.
 
+        Performs the following checks:
+        1. The file is valid JSON
+        2. Contains exactly one 'neuron' or 'neurons' key
+        3. Exactly one neuron is present
+        4. Soma is present with 'x', 'y', and 'z' keys
+        5. Axon/dendrite compartments (if present) contain root nodes
+        """
         try:
             file_content = read_file(self.path_to_file)
             data = json.loads(file_content)
-            # Add your JSON validation logic here using json_data
         except json.JSONDecodeError as e:
             raise ValueError(f"Invalid JSON file: {e}")
         except Exception as e:
             raise ValueError(f"Error reading JSON file: {e}")
-        data_keys = list(data.keys())
-        indicators = ['neuron', 'neurons']
-        if not any([i in data_keys for i in indicators]):
-            raise ValueError("input json must have 'neurons' or 'neuron' key")
-        if all([i in data_keys for i in indicators]):
-            raise ValueError("input json contains both 'neurons' and 'neuron' keys, unsure which to use")
 
-        if 'neurons' in data_keys:
-            neuron_dicts = data['neurons']
-        elif 'neuron' in data_keys:
-            neuron_dicts = [data['neuron']]
-        else:
-            neuron_dicts = []
+        neuron_dicts = self._extract_neuron_list(data)
+        self._validate_single_neuron(neuron_dicts)
 
-        if neuron_dicts == []:
-            raise ValueError("at least one neuron must be contained within the 'neurons' or 'neuron' value")
+        for neuron in neuron_dicts:
+            self._validate_soma(neuron)
+            self._validate_compartments(neuron)
 
+    # ---------------------------------------------------------------------
+    # Internal helper methods used only by `validate_json`
+    # ---------------------------------------------------------------------
+    def _extract_neuron_list(self, data):
+        """
+        Extract the list of neurons from the JSON data.
+
+        Only used by `validate_json`. Ensures exactly one of 'neuron' or 'neurons' is present.
+        """
+        keys = list(data.keys())
+        if not any(k in keys for k in ("neuron", "neurons")):
+            raise ValueError("Input JSON must have 'neurons' or 'neuron' key")
+        if all(k in keys for k in ("neuron", "neurons")):
+            raise ValueError(
+                "Input JSON contains both 'neurons' and 'neuron' keys")
+
+        if "neurons" in data:
+            return data["neurons"]
+        if "neuron" in data:
+            return [data["neuron"]]
+        return []
+
+    def _validate_single_neuron(self, neuron_dicts):
+        """
+        Ensure that exactly one neuron is present.
+
+        Only used by `validate_json`.
+        """
+        if not neuron_dicts:
+            raise ValueError("No neuron data found in the file")
         if len(neuron_dicts) != 1:
-            raise ValueError(f"Each mouselight .json file should contain 1 neuron but {len(neuron_dicts)} were found")
+            raise ValueError(
+                f"Each mouselight .json file should contain 1 neuron but {len(neuron_dicts)} were found"
+            )
 
-    
-        for neuron_dictionary in neuron_dicts:  
-            if "soma" not in neuron_dictionary:
-                raise ValueError("No soma node detected in the input neuron ") 
-            if not all([key in neuron_dictionary['soma'] for key in ['x','y','z']]):
-                raise ValueError("'x', 'y' and 'z' are required for the soma node")
-            
-            for compartment in ['axon', 'dendrite']:
+    def _validate_soma(self, neuron):
+        """
+        Verify that the neuron contains a valid soma node with x, y, z coordinates.
 
-                if compartment in neuron_dictionary:
-                    these_nodes = neuron_dictionary[compartment]
-                    if these_nodes:
-                        roots = [n for n in these_nodes if n['parentNumber']==-1]
-                        if roots == []:
-                            raise ValueError(f"{compartment} compartment does not have a root node (i.e. a node with parent = -1) ") 
-              
-                            
+        Only used by `validate_json`.
+        """
+        if "soma" not in neuron:
+            raise ValueError("No soma node detected in the input neuron")
+        if not all(coord in neuron["soma"] for coord in ("x", "y", "z")):
+            raise ValueError("'x', 'y' and 'z' are required for the soma node")
+
+    def _validate_compartments(self, neuron):
+        """
+        Verify that axon and dendrite compartments (if present) contain at least one root node.
+
+        Only used by `validate_json`.
+        """
+        for compartment in ("axon", "dendrite"):
+            if compartment in neuron:
+                nodes = neuron[compartment]
+                if nodes:
+                    roots = [n for n in nodes if n.get("parentNumber") == -1]
+                    if not roots:
+                        raise ValueError(
+                            f"{compartment} compartment does not have a root node (i.e., parentNumber = -1)"
+                        )
+
     def validate_swc(self):
-        file_content = read_file(self.path_to_file)
-        lines = file_content.splitlines()
-
+        """Validate swc file"""
         try:
             file_content = read_file(self.path_to_file)
             lines = file_content.splitlines()
@@ -169,17 +232,18 @@ class NeuronData(pd.DataFrame):
             raise ValueError(err_msg) from e
 
     def validate_h5(self):
-        #TODO
+        """To Do"""
+        # TODO
         True
         return None
-         
+
     def validate_precomputed(self):
         """
         Requires:
         1) the precomputed file exists
         2) The neuroglancer files should be formatted as follows:
-        
-            project_directory 
+
+            project_directory
                 info
                 skeleton
                     1324
@@ -189,59 +253,74 @@ class NeuronData(pd.DataFrame):
         3) that the precomputed file passed into NeuronData is an integer (e.g. 1324)
         """
         if not file_exists(self.path_to_file):
-            raise ValueError(f"Provided input file does not exists:\n{self.path_to_file}")
+            raise ValueError(
+                f"Provided input file does not exists:\n{self.path_to_file}"
+            )
 
         # the info file should be one directory up from the provided path
         project_dir = get_grandparent_dir(self.path_to_file)
         project_info_file = f"{project_dir}/info"
         if not file_exists(project_info_file):
-            raise ValueError(f"neuroglancer info file not found. Expected one at the following path:\n{project_info_file}")        
+            raise ValueError(
+                f"neuroglancer info file not found. Expected one at the following path:\n{project_info_file}"
+            )
         self.project_directory = project_dir
-        
+
         neuron_id = get_basename(self.path_to_file)
         try:
             neuron_id = int(neuron_id)
-            
+
         except ValueError as e:
             err_msg = f"Could not interpret precomputed neuron id as integer.\nInput file:\n {self.path_to_file}\n Derived neuron id: {neuron_id}"
             raise ValueError(err_msg) from e
-        
-        
+
         self.neuron_id = neuron_id
-        
-        
+
     def load_data(self):
-        
+        """Load the data according to extension type
+
+        Returns:
+            pd.DataFrame: basis for NeuronData
+        """
         # Load data based on file type
         file_extension = get_file_extension(self.path_to_file)
-        if file_extension == '.json':
-            neuron_df =  io.read_json(self.path_to_file, self.ccf_annotate_vertices)
-        elif file_extension == '.swc':
-            neuron_df = io.read_swc(self.path_to_file, self.ccf_annotate_vertices)
+        if file_extension == ".json":
+            neuron_df = io.read_json(
+                self.path_to_file, self.ccf_annotate_vertices
+            )
+        elif file_extension == ".swc":
+            neuron_df = io.read_swc(
+                self.path_to_file, self.ccf_annotate_vertices
+            )
         elif file_extension == ".h5":
-            neuron_df  = io.read_h5(self.path_to_file, self.ccf_annotate_vertices)
+            neuron_df = io.read_h5(
+                self.path_to_file, self.ccf_annotate_vertices
+            )
         else:
-            neuron_df = io.read_precomputed(self.project_directory, self.neuron_id, self.ccf_annotate_vertices)
+            neuron_df = io.read_precomputed(
+                self.project_directory,
+                self.neuron_id,
+                self.ccf_annotate_vertices,
+            )
 
-        # for loop below is useful if we want to add things like NeuronData.get_children(node_id)
-        parent_ids_dict = dict(zip(neuron_df["node_id"],neuron_df["parent"]))
-        child_ids_dict = { nid:[] for nid in parent_ids_dict }
+        # for loop below would be usefule to add things like NeuronData.get_children(node_id)
+        # parent_ids_dict = dict(zip(neuron_df["node_id"],neuron_df["parent"]))
+        # child_ids_dict = { nid:[] for nid in parent_ids_dict }
         # for nid in parent_ids_dict:
         #     pid = parent_ids_dict[nid]
         #     if pid != -1:
         #         child_ids_dict[pid].append(nid)
-        
+
         # create the child look up dictionary
-        self._child_ids_dict = child_ids_dict
+        # self._child_ids_dict = child_ids_dict
         return neuron_df
-          
-               
+
     def to_precomputed(self, outfile):
         """
-        Write NeuronData to binary precomputed file for neuroglancer. This will 
-        initialize a info file for the output directory, create a skeletons directory, 
+        Write NeuronData to binary precomputed file for neuroglancer. This will
+        initialize a info file for the output directory, create a skeletons directory,
         add an info file there and write the skeleton to a precomputed format.
-                
+
         Args:
             outfile (str): path to output file, the file name should be the "segid" i.e.
                            the unique neuroglancer id for this neuron (e.g. /path/to/1000)
@@ -252,91 +331,97 @@ class NeuronData(pd.DataFrame):
         output_dir_cp = fix_local_cloudpath(output_dir)
 
         info = cloudvolume.CloudVolume.create_new_info(
-            num_channels    = 1,
-            mesh            = "mesh",
-            layer_type      = 'segmentation',
-            data_type       = 'uint64', # Channel images might be 'uint8'
+            num_channels=1,
+            mesh="mesh",
+            layer_type="segmentation",
+            data_type="uint64",  # Channel images might be 'uint8'
             # raw, png, jpeg, compressed_segmentation, fpzip, kempressed, zfpc, compresso, crackle
-            encoding        = 'raw', 
-            resolution      = [1000,1000,1000], # Voxel scaling, units are in nanometers
-            voxel_offset    = [0, 0, 0], # x,y,z offset in voxels from the origin
-            skeletons        = 'skeleton',
+            encoding="raw",
+            resolution=[
+                1000,
+                1000,
+                1000,
+            ],  # Voxel scaling, units are in nanometers
+            voxel_offset=[0, 0, 0],  # x,y,z offset in voxels from the origin
+            skeletons="skeleton",
             # Pick a convenient size for your underlying chunk representation
             # Powers of two are recommended, doesn't need to cover image exactly
-            chunk_size      = [ 512,512,512], #the voxels
-            volume_size = [13200,8000,11400]
+            chunk_size=[512, 512, 512],  # the voxels
+            volume_size=[13200, 8000, 11400],
         )
-        info['segment_properties']='segment_properties'
-        #correct location
-        cv = cloudvolume.CloudVolume(output_dir_cp , mip=0, info=info, compress=False)
+        info["segment_properties"] = "segment_properties"
+        # correct location
+        cv = cloudvolume.CloudVolume(
+            output_dir_cp, mip=0, info=info, compress=False
+        )
         cv.commit_info()
-        
-        sk_info = cv.skeleton.meta.default_info()
-        sk_info['transform'] = [1000, 0, 0, 0, 0, 1000, 0, 0, 0, 0, 1000, 0]
-        sk_info['vertex_attributes'] = [
-            { 'id': 'radius',
-                'data_type': 'float32',
-                'num_components': 1
-            },
-            {
-                'id': 'allenId',
-                'data_type': 'float32',
-                'num_components': 1
-            },
-            {
-                'id': 'compartment',
-                'data_type': 'int',
-                'num_components': 1
-            },
-            {
-                'id': 'presynaptic_count',
-                'data_type': 'float32',
-                'num_components': 1
-            },
-            {
-                'id': 'postsynaptic_count',
-                'data_type': 'float32',
-                'num_components': 1
-            }
 
+        sk_info = cv.skeleton.meta.default_info()
+        sk_info["transform"] = [1000, 0, 0, 0, 0, 1000, 0, 0, 0, 0, 1000, 0]
+        vert_atts = []
+
+        sk_info["vertex_attributes"] = [
+            {"id": "radius", "data_type": "float32", "num_components": 1},
+            {"id": "compartment", "data_type": "float32", "num_components": 1},
         ]
         cv.skeleton.meta.info = sk_info
         cv.skeleton.meta.commit_info()
 
-        vertices = self[['x','y','z']].values
+        vertices = self[["x", "y", "z"]].values
 
         node_id_toindex = dict(zip(self.node_id, self.index))
         # get edges
-        edge_df = self.loc[self['parent']!=-1]
+        edge_df = self.loc[self["parent"] != -1]
         edge_ids = edge_df.node_id.map(node_id_toindex)
         parent_ids = edge_df.parent.map(node_id_toindex)
         # relabel the edges so that they are the index aligned with the vertices
         edges_relabeled = np.column_stack((edge_ids, parent_ids))
 
-        radius = self['r'].values.astype(np.float32)
-        vertex_types = self['compartment'].values.astype(int) #np.float32)
+        radius = self["r"].values.astype(np.float32)
+        vertex_types = self["compartment"].values.astype(int)  # np.float32)
 
-        sk_cv = cloudvolume.Skeleton(vertices,
-                                     edges_relabeled,
-                                     radius,
-                                     None, 
-                                     segid=segid,
-                                     extra_attributes = sk_info['vertex_attributes']
-                                     )
+        sk_cv = cloudvolume.Skeleton(
+            vertices,
+            edges_relabeled,
+            radius,
+            None,
+            segid=segid,
+            extra_attributes=sk_info["vertex_attributes"],
+        )
         if "allenId" in self.columns:
-          sk_cv.allenId = self.allenId.values
+            sk_cv.allenId = self.allenId.values
+            vert_atts.append(
+                {"id": "allenId", "data_type": "float32", "num_components": 1}
+            )
+
         if "postsynaptic_count" in self.columns:
-          sk_cv.postsynaptic_count = self.postsynaptic_count.values
+            sk_cv.postsynaptic_count = self.postsynaptic_count.values
+            vert_atts.append(
+                {
+                    "id": "postsynaptic_count",
+                    "data_type": "float32",
+                    "num_components": 1,
+                }
+            )
+
         if "presynaptic_count" in self.columns:
-          sk_cv.presynaptic_count = self.presynaptic_count.values
-          
+            sk_cv.presynaptic_count = self.presynaptic_count.values
+            vert_atts.append(
+                {
+                    "id": "presynaptic_count",
+                    "data_type": "float32",
+                    "num_components": 1,
+                }
+            )
+
         sk_cv.compartment = vertex_types
-        
+
         cv.skeleton.upload(sk_cv)
-        
-        
-        
-def neurondata_list_to_precomputed(list_of_neuron_data, output_dir, neuron_ids = None):
+
+
+def neurondata_list_to_precomputed(
+    list_of_neuron_data, output_dir, neuron_ids=None
+):
     """
     Will write a list of NeuronData objects to an output directory organized for neuroglancer
     visualizations.
@@ -346,99 +431,97 @@ def neurondata_list_to_precomputed(list_of_neuron_data, output_dir, neuron_ids =
         output_dir (str): path to output neuroglancer dir
         neuron_ids (list): list of neuron IDs (integers), if not provided will just
         use the NeuronDatas index in the list.
-        
+
     """
     if not file_exists(output_dir):
         create_directory(output_dir)
-    
+
     if neuron_ids is not None:
-        if len(neuron_ids)!=len(list_of_neuron_data):
-            raise ValueError(f"Length of neruon_ids {len(neuron_ids)} does not match length of neuron data ({len(list_of_neuron_data)})")
+        if len(neuron_ids) != len(list_of_neuron_data):
+            raise ValueError(
+                f"Length of neruon_ids {len(neuron_ids)} does not match length of neuron data ({len(list_of_neuron_data)})"
+            )
     else:
-        neuron_ids = [i+1 for i in range(len(list_of_neuron_data))]
-        
+        neuron_ids = [i + 1 for i in range(len(list_of_neuron_data))]
+
     output_dir_cp = fix_local_cloudpath(output_dir)
 
     info = cloudvolume.CloudVolume.create_new_info(
-        num_channels    = 1,
-        mesh            = "mesh",
-        layer_type      = 'segmentation',
-        data_type       = 'uint64', # Channel images might be 'uint8'
+        num_channels=1,
+        mesh="mesh",
+        layer_type="segmentation",
+        data_type="uint64",  # Channel images might be 'uint8'
         # raw, png, jpeg, compressed_segmentation, fpzip, kempressed, zfpc, compresso, crackle
-        encoding        = 'raw', 
-        resolution      = [1000,1000,1000], # Voxel scaling, units are in nanometers
-        voxel_offset    = [0, 0, 0], # x,y,z offset in voxels from the origin
-        skeletons        = 'skeleton',
+        encoding="raw",
+        resolution=[
+            1000,
+            1000,
+            1000,
+        ],  # Voxel scaling, units are in nanometers
+        voxel_offset=[0, 0, 0],  # x,y,z offset in voxels from the origin
+        skeletons="skeleton",
         # Pick a convenient size for your underlying chunk representation
         # Powers of two are recommended, doesn't need to cover image exactly
-        chunk_size      = [ 512,512,512], #the voxels
-        volume_size = [13200,8000,11400]
+        chunk_size=[512, 512, 512],  # the voxels
+        volume_size=[13200, 8000, 11400],
     )
-    info['segment_properties']='segment_properties'
-    #correct location
-    cv = cloudvolume.CloudVolume(output_dir_cp , mip=0, info=info, compress=False)
+    info["segment_properties"] = "segment_properties"
+    # correct location
+    cv = cloudvolume.CloudVolume(
+        output_dir_cp, mip=0, info=info, compress=False
+    )
     cv.commit_info()
-    
-    sk_info = cv.skeleton.meta.default_info()
-    sk_info['transform'] = [1000, 0, 0, 0, 0, 1000, 0, 0, 0, 0, 1000, 0]
-    sk_info['vertex_attributes'] = [
-        { 'id': 'radius',
-            'data_type': 'float32',
-            'num_components': 1
-        },
-        {
-            'id': 'allenId',
-            'data_type': 'float32',
-            'num_components': 1
-        },
-        {
-            'id': 'compartment',
-            'data_type': 'int',
-            'num_components': 1
-        },
-        {
-            'id': 'presynaptic_count',
-            'data_type': 'float32',
-            'num_components': 1
-        },
-        {
-            'id': 'postsynaptic_count',
-            'data_type': 'float32',
-            'num_components': 1
-        }
 
+    sk_info = cv.skeleton.meta.default_info()
+    sk_info["transform"] = [1000, 0, 0, 0, 0, 1000, 0, 0, 0, 0, 1000, 0]
+    sk_info["vertex_attributes"] = [
+        {"id": "radius", "data_type": "float32", "num_components": 1},
+        {"id": "allenId", "data_type": "float32", "num_components": 1},
+        {"id": "compartment", "data_type": "float32", "num_components": 1},
+        {
+            "id": "presynaptic_count",
+            "data_type": "float32",
+            "num_components": 1,
+        },
+        {
+            "id": "postsynaptic_count",
+            "data_type": "float32",
+            "num_components": 1,
+        },
     ]
     cv.skeleton.meta.info = sk_info
     cv.skeleton.meta.commit_info()
 
     skeletons = []
-    for neuron_data,neuron_id in zip(list_of_neuron_data,neuron_ids):
-            
-        vertices = neuron_data[['x','y','z']].values
+    for neuron_data, neuron_id in zip(list_of_neuron_data, neuron_ids):
+
+        vertices = neuron_data[["x", "y", "z"]].values
 
         node_id_toindex = dict(zip(neuron_data.node_id, neuron_data.index))
         # get edges
-        edge_df = neuron_data.loc[neuron_data['parent']!=-1]
+        edge_df = neuron_data.loc[neuron_data["parent"] != -1]
         edge_ids = edge_df.node_id.map(node_id_toindex)
         parent_ids = edge_df.parent.map(node_id_toindex)
         # relabel the edges so that they are the index aligned with the vertices
         edges_relabeled = np.column_stack((edge_ids, parent_ids))
 
-        radius = neuron_data['r'].values.astype(np.float32)
-        vertex_types = neuron_data['compartment'].values.astype(int) #np.float32)
-        
-        sk_cv = cloudvolume.Skeleton(vertices,
-                                        edges_relabeled,
-                                        radius,
-                                        None, 
-                                        segid=neuron_id,
-                                        extra_attributes = sk_info['vertex_attributes']
-                                        )
+        radius = neuron_data["r"].values.astype(np.float32)
+        vertex_types = neuron_data["compartment"].values.astype(
+            int
+        )  # np.float32)
+
+        sk_cv = cloudvolume.Skeleton(
+            vertices,
+            edges_relabeled,
+            radius,
+            None,
+            segid=neuron_id,
+            extra_attributes=sk_info["vertex_attributes"],
+        )
         sk_cv.allenId = neuron_data.allenId.values
         sk_cv.postsynaptic_count = neuron_data.postsynaptic_count.values
         sk_cv.presynaptic_count = neuron_data.presynaptic_count.values
         sk_cv.compartment = vertex_types
-        
+
         skeletons.append(sk_cv)
     cv.skeleton.upload(skeletons)
-

--- a/src/aind_neuron_reconstruction_io/NeuronData.py
+++ b/src/aind_neuron_reconstruction_io/NeuronData.py
@@ -226,7 +226,7 @@ class NeuronData(pd.DataFrame):
         """Validate swc file"""
         try:
             file_content = read_file(self.path_to_file)
-            lines = file_content.splitlines()
+            file_content.splitlines()
         except Exception as e:
             err_msg = f"Invalid SWC file: {self.path_to_file}"
             raise ValueError(err_msg) from e

--- a/src/aind_neuron_reconstruction_io/NeuronData.py
+++ b/src/aind_neuron_reconstruction_io/NeuronData.py
@@ -214,13 +214,13 @@ class NeuronData(pd.DataFrame):
         else:
             neuron_df = io.read_precomputed(self.project_directory, self.neuron_id, self.ccf_annotate_vertices)
 
-        # this computation is useful if we want to add things like NeuronData.get_children(node_id)
+        # for loop below is useful if we want to add things like NeuronData.get_children(node_id)
         parent_ids_dict = dict(zip(neuron_df["node_id"],neuron_df["parent"]))
         child_ids_dict = { nid:[] for nid in parent_ids_dict }
-        for nid in parent_ids_dict:
-            pid = parent_ids_dict[nid]
-            if pid != -1:
-                child_ids_dict[pid].append(nid)
+        # for nid in parent_ids_dict:
+        #     pid = parent_ids_dict[nid]
+        #     if pid != -1:
+        #         child_ids_dict[pid].append(nid)
         
         # create the child look up dictionary
         self._child_ids_dict = child_ids_dict
@@ -432,7 +432,7 @@ def neurondata_list_to_precomputed(list_of_neuron_data, output_dir, neuron_ids =
     
 def meshwork_skeleton_to_neurondata(mw, ccf_annotate_vertices, get_compartment_labels):
     """
-    Will convert a meshwork skeleton to a NeuronData object
+    Will convert a meshwork object to a NeuronData object
 
 
     Args:
@@ -509,8 +509,6 @@ def meshwork_skeleton_to_neurondata(mw, ccf_annotate_vertices, get_compartment_l
         
     
     neuron_df = neuron_df[['node_id','compartment','x','y','z','r','parent','allenId','presynaptic_count','postsynaptic_count']]
-    
-
         
     neuron_data = NeuronData(input_data=neuron_df,ccf_annotate_vertices=False)
     

--- a/src/aind_neuron_reconstruction_io/NeuronData.py
+++ b/src/aind_neuron_reconstruction_io/NeuronData.py
@@ -323,9 +323,13 @@ class NeuronData(pd.DataFrame):
                                      segid=segid,
                                      extra_attributes = sk_info['vertex_attributes']
                                      )
-        sk_cv.allenId = self.allenId.values
-        sk_cv.postsynaptic_count = self.postsynaptic_count.values
-        sk_cv.presynaptic_count = self.presynaptic_count.values
+        if "allenId" in self.columns:
+          sk_cv.allenId = self.allenId.values
+        if "postsynaptic_count" in self.columns:
+          sk_cv.postsynaptic_count = self.postsynaptic_count.values
+        if "presynaptic_count" in self.columns:
+          sk_cv.presynaptic_count = self.presynaptic_count.values
+          
         sk_cv.compartment = vertex_types
         
         cv.skeleton.upload(sk_cv)

--- a/src/aind_neuron_reconstruction_io/__init__.py
+++ b/src/aind_neuron_reconstruction_io/__init__.py
@@ -1,2 +1,3 @@
 """Init package"""
+
 __version__ = "0.0.0"

--- a/src/aind_neuron_reconstruction_io/io.py
+++ b/src/aind_neuron_reconstruction_io/io.py
@@ -105,7 +105,7 @@ def read_swc(input_file, ccf_annotate_vertices, separator=' '):
     Returns:
         swc_df: DataFrame  
     """
-    # pandas >=0.24 will allow reading directly from cloud paths
+    # pandas >=0.24 will allow reading directly from cloud locations
     swc_df = pd.read_csv(input_file,
                     sep=separator,
                     comment='#',

--- a/src/aind_neuron_reconstruction_io/io.py
+++ b/src/aind_neuron_reconstruction_io/io.py
@@ -1,0 +1,281 @@
+import os
+import json
+import nrrd
+from collections import deque
+import numpy as np
+import pandas as pd
+import cloudvolume
+from importlib.resources import files
+from six import iteritems
+from aind_neuron_reconstruction_io.utils import fix_local_cloudpath, read_file
+
+_cached_ccf_annotation = None
+
+def load_ccf_annotation():
+    """load ccf annotation using numpy array where the axes dimensions are as follows
+    0 = x = anterior-posterior
+    1 = y = dorsal-ventral
+    2 = z = medial-lateral
+
+    Returns:
+        numpy array: 3-d numpy array where values represent structure IDs
+    """
+    annotation_path =  files('aind_neuron_reconstruction_io') / 'util_files/annotation_10.nrrd'
+    annotation, _ = nrrd.read(annotation_path)
+
+    return annotation
+
+def get_cached_ccf_annotation():
+    """Retrieve the cached CCF annotation or load it if not already cached"""
+    global _cached_ccf_annotation
+    if _cached_ccf_annotation is None:
+        _cached_ccf_annotation = load_ccf_annotation()
+    return _cached_ccf_annotation
+
+def annotate_ccf_structure(input_df, x_col='x', y_col='y', z_col='z'):
+    """given a dataframe with columns representing the x, y and z (anterior-posterior, dorsal-ventral
+    and left-right, respectively), will add a column 'allenId' to the dataframe representing the 
+    CCF structure Id each node resides in
+
+    Args:
+        input_df (pd.DataFrame): 
+        x_col (str, optional): x column name. Defaults to 'x'.
+        y_col (str, optional): y column name. Defaults to 'y'.
+        z_col (str, optional): z column name. Defaults to 'z'.
+
+
+    Returns:
+        None
+    """
+    
+    if not all([d in input_df.columns for d in [x_col, y_col, z_col]]):
+        raise ValueError(
+            "dimension column names must be in input_df columns. Columns provided: "
+            f"{x_col}, {y_col}, {z_col}")
+    
+    ccf_annotation = get_cached_ccf_annotation()
+    
+    def annotate_row(x,y,z, annotation=ccf_annotation, annotation_resolution = 10):
+        """
+        Scale a given coordinate to the atlas resolution and
+        return the structure-ID for the given coordinate. Returns
+        0 if the passed [x,y,z] coordinate is out of brain. 
+
+        Args:
+            x (int): x-voxel
+            y (int): y-voxel
+            z (int): z-voxel
+            annotation_resolution (int): resolution of the annotation atlas
+            annotation (array): 3d numpy array with annotation data. Defaults to ccf_annotation.
+
+        Returns:
+            int: ccf structure ID
+        """
+        volume_shape = (1320, 800, 1140)
+        voxel = [
+            np.floor(x / annotation_resolution).astype(int),
+            np.floor(y / annotation_resolution).astype(int),
+            np.floor(z / annotation_resolution).astype(int)
+        ]
+        for dim in [0,1,2]:
+            if voxel[dim] >= volume_shape[dim]:
+                return 0
+        
+        return annotation[voxel[0], voxel[1], voxel[2]]
+        
+    input_df['allenId'] = input_df.apply(lambda row: annotate_row(x = row[x_col], y = row[y_col], z = row[z_col]), axis=1)
+
+
+
+def read_swc(input_file, separator=' '):
+    """
+    Will load a ccf-registered swc file 
+
+    Args:
+        input_file (str): path to swc file to load
+        separator (str): space separator 
+      
+    Returns:
+        swc_df: DataFrame  
+    """
+    # pandas >=0.24 will allow reading directly from cloud paths
+    swc_df = pd.read_csv(input_file,
+                    sep=separator,
+                    comment='#',
+                    header=None,
+                    names=['node_id', 'type', 'x', 'y', 'z', 'r', 'parent'])
+    # swc_df.set_index("node_id",inplace=True)
+    
+    annotate_ccf_structure(swc_df, x_col='x', y_col='y', z_col='z')
+
+    return swc_df
+
+        
+
+def read_json(input_file):
+    """
+    Will load a ccf-registered mouselight json file.
+    
+    Args:
+        input_file (str): path to mouselight json
+        
+    Returns:
+        nrn_df: DataFrame
+    """
+    
+    compartments = ['axon','dendrite']
+
+    file_content = read_file(input_file)
+    data_dict = json.loads(file_content)
+    
+    neuron_list = data_dict['neurons']
+    
+    # as per validation of the input file, there should be exactly one neuron in neuron_list
+    neuron_dict = neuron_list[0]
+        
+    soma = neuron_dict['soma']
+    soma_rad = soma['radius'] if 'radius' in soma else 0
+    soma_struct = 0
+    
+    # check if cell has node level ccf annotations
+    has_ccf_annotations = False
+    if 'allenId' in soma:
+        soma_struct = soma['allenId']
+        has_ccf_annotations = True
+        
+    soma_data = [
+        1,
+        1,
+        soma['x'],
+        soma['y'],
+        soma['z'],
+        soma_rad,
+        -1,
+        soma_struct
+    ]
+
+    this_neuron_node_list = [soma_data]
+    node_count = 1
+    for node_type_str in compartments:
+        
+        # dictionary that tracks node ids from the compartment tree level (local)
+        # to their ID in the entire neuron tree (global)
+        local_id_to_global_id = {1:1}
+        
+        # get list of nodes in this compartment
+        if node_type_str in neuron_dict:
+            compartment_node_list = neuron_dict[node_type_str]
+        else:
+            compartment_node_list = []
+
+        # look up tables for parent-child relationships
+        node_id_to_node = { n['sampleNumber'] : n for n in compartment_node_list }
+        parent_ids_dict = { nid: n['parentNumber'] for nid,n in iteritems(node_id_to_node) }
+        child_ids_dict = { nid:[] for nid in node_id_to_node }
+        for nid in parent_ids_dict:
+            pid = parent_ids_dict[nid]
+            if pid != -1:
+                child_ids_dict[pid].append(nid)
+
+        # find root nodes of this compartment tree
+        root_nodes = [n for n in compartment_node_list if n['parentNumber']==-1]
+        for root in root_nodes:
+            
+            if [soma['x'], soma['y'], soma['z']] == [root['x'], root['y'], root['z']]:
+                # this root is the same as the soma, 
+                # just append its children to the queue
+                roots_children = [node_id_to_node[i] for i in child_ids_dict[root['sampleNumber']]]
+                this_queue = deque(roots_children)
+                
+            else:
+                # this is a root that is separate from the soma, therfore begin the
+                # queue with this root
+                this_queue = deque([root])
+            
+            # iterate over this tree with dfs 
+            while len(this_queue) > 0:
+                
+                node_count+=1
+                this_node = this_queue.popleft()
+                
+                
+                # get local (within subtree) ID and global ID (across entire neuron)
+                local_id = this_node['sampleNumber']
+                global_id = node_count
+                local_id_to_global_id[local_id] = global_id
+                
+                local_parent_id = this_node['parentNumber']
+                
+                if local_parent_id == -1:
+                    # this_node is a new root node
+                    global_parent_id = -1 
+                else:
+                    global_parent_id = local_id_to_global_id[local_parent_id]
+                
+                children = [node_id_to_node[i] for i in child_ids_dict[local_id]]
+                for child in children:
+                    this_queue.appendleft(child)
+                    
+                node_struct = this_node['allenId'] if 'allenId' in this_node else 0
+                
+                record = [
+                    global_id, 
+                    this_node['structureIdentifier'],
+                    this_node['x'], 
+                    this_node['y'], 
+                    this_node['z'], 
+                    this_node['radius'],
+                    global_parent_id, 
+                    node_struct
+                ]
+                
+                this_neuron_node_list.append(record)
+
+    col_list = ['node_id', 'type', 'x', 'y', 'z', 'r', 'parent', 'allenId']
+    nrn_df = pd.DataFrame(this_neuron_node_list, columns = col_list)
+    if not has_ccf_annotations:
+        annotate_ccf_structure(nrn_df, x_col='x', y_col='y', z_col='z')
+    
+        
+    return nrn_df
+
+
+def read_precomputed(project_directory, skeleton_id):
+    """load a precomputed neuroglancer file into a dataframe. The input project directory should 
+    follow the format as seen below:
+    
+    project_directory 
+        info
+        skeleton
+            1324
+            1422
+            1950
+            info
+
+    Where 1324, 1422 and 1950 are precomputed files. These would be valid skeleton_id values to pass
+    into this function.
+
+    Args:
+        project_directory (str): path to neuroglancer project level directory
+        skeleton_id (int): the integer id of the skeleton to load
+
+    Returns:
+        swc_df: neuron dataframe
+    """
+    project_directory_cv = fix_local_cloudpath(project_directory)
+    cv = cloudvolume.CloudVolume(project_directory_cv)
+    skel = cv.skeleton.get(skeleton_id)
+    swc_string = skel.to_swc()
+    swc_lines = [l for l in swc_string.split("\n") if (not l.startswith("#")) and (l!="")]
+    swc_lines_arr = [ [float(i) for i in l.split()] for l in swc_lines]
+    column_headers = ['node_id', 'type', 'x', 'y', 'z', 'r', 'parent']
+    swc_df = pd.DataFrame(swc_lines_arr, columns= column_headers)
+    swc_df[['x','y','z']] = swc_df[['x','y','z']]/1000
+    annotate_ccf_structure(swc_df, x_col='x', y_col='y', z_col='z')
+    
+    swc_df['node_id'] = swc_df['node_id'].astype(int)
+    swc_df['type'] = swc_df['type'].astype(int)
+    swc_df['parent'] = swc_df['parent'].astype(int)
+    swc_df['parent'] = swc_df['parent'].astype(int)
+    
+    return swc_df

--- a/src/aind_neuron_reconstruction_io/io.py
+++ b/src/aind_neuron_reconstruction_io/io.py
@@ -12,7 +12,7 @@ import nrrd
 import numpy as np
 import pandas as pd
 from cloudfiles import CloudFiles
-from meshparty import meshwork, skeleton
+from meshparty import meshwork
 from six import iteritems
 
 from aind_neuron_reconstruction_io.NeuronData import NeuronData

--- a/src/aind_neuron_reconstruction_io/io.py
+++ b/src/aind_neuron_reconstruction_io/io.py
@@ -1,21 +1,31 @@
-import os
-import json
-import nrrd
+"""
+This module provides the io operations to support NeuronData.
+"""
+
 import io
+import json
 from collections import deque
+from importlib.resources import files
+
+import cloudvolume
+import nrrd
 import numpy as np
 import pandas as pd
-import cloudvolume
-from importlib.resources import files
-from six import iteritems
 from cloudfiles import CloudFiles
-from meshparty import skeleton, meshwork
-from aind_neuron_reconstruction_io.utils import (fix_local_cloudpath, read_file, 
-                                                 pull_mw_skel_colors,
-                                                  get_parent_dir,get_basename)
+from meshparty import meshwork, skeleton
+from six import iteritems
 
+from aind_neuron_reconstruction_io.NeuronData import NeuronData
+from aind_neuron_reconstruction_io.utils import (
+    fix_local_cloudpath,
+    get_basename,
+    get_parent_dir,
+    pull_mw_skel_colors,
+    read_file,
+)
 
 _cached_ccf_annotation = None
+
 
 def load_ccf_annotation():
     """load ccf annotation using numpy array where the axes dimensions are as follows
@@ -26,25 +36,34 @@ def load_ccf_annotation():
     Returns:
         numpy array: 3-d numpy array where values represent structure IDs
     """
-    annotation_path =  files('aind_neuron_reconstruction_io') / 'util_files/annotation_10.nrrd'
+    annotation_path = (
+        files("aind_neuron_reconstruction_io")
+        / "util_files/annotation_10.nrrd"
+    )
     annotation, _ = nrrd.read(annotation_path)
 
     return annotation
 
+
 def get_cached_ccf_annotation():
-    """Retrieve the cached CCF annotation or load it if not already cached"""
+    """Retrieve the cached CCF annotation or load it if not already cached
+
+    Returns:
+        np.array: cached ccf annotation volume
+    """
     global _cached_ccf_annotation
     if _cached_ccf_annotation is None:
         _cached_ccf_annotation = load_ccf_annotation()
     return _cached_ccf_annotation
 
-def annotate_ccf_structure(input_df, x_col='x', y_col='y', z_col='z'):
+
+def annotate_ccf_structure(input_df, x_col="x", y_col="y", z_col="z"):
     """given a dataframe with columns representing the x, y and z (anterior-posterior, dorsal-ventral
-    and left-right, respectively), will add a column 'allenId' to the dataframe representing the 
+    and left-right, respectively), will add a column 'allenId' to the dataframe representing the
     CCF structure Id each node resides in
 
     Args:
-        input_df (pd.DataFrame): 
+        input_df (pd.DataFrame):
         x_col (str, optional): x column name. Defaults to 'x'.
         y_col (str, optional): y column name. Defaults to 'y'.
         z_col (str, optional): z column name. Defaults to 'z'.
@@ -53,19 +72,22 @@ def annotate_ccf_structure(input_df, x_col='x', y_col='y', z_col='z'):
     Returns:
         None
     """
-    
+
     if not all([d in input_df.columns for d in [x_col, y_col, z_col]]):
         raise ValueError(
             "dimension column names must be in input_df columns. Columns provided: "
-            f"{x_col}, {y_col}, {z_col}")
-    
+            f"{x_col}, {y_col}, {z_col}"
+        )
+
     ccf_annotation = get_cached_ccf_annotation()
-    
-    def annotate_row(x,y,z, annotation=ccf_annotation, annotation_resolution = 10):
+
+    def annotate_row(
+        x, y, z, annotation=ccf_annotation, annotation_resolution=10
+    ):
         """
         Scale a given coordinate to the atlas resolution and
         return the structure-ID for the given coordinate. Returns
-        0 if the passed [x,y,z] coordinate is out of brain. 
+        0 if the passed [x,y,z] coordinate is out of brain.
 
         Args:
             x (int): x-voxel
@@ -81,95 +103,136 @@ def annotate_ccf_structure(input_df, x_col='x', y_col='y', z_col='z'):
         voxel = [
             np.floor(x / annotation_resolution).astype(int),
             np.floor(y / annotation_resolution).astype(int),
-            np.floor(z / annotation_resolution).astype(int)
+            np.floor(z / annotation_resolution).astype(int),
         ]
-        for dim in [0,1,2]:
+        for dim in [0, 1, 2]:
             if voxel[dim] >= volume_shape[dim]:
                 return 0
-        
+
         return annotation[voxel[0], voxel[1], voxel[2]]
-        
-    input_df['allenId'] = input_df.apply(lambda row: annotate_row(x = row[x_col], y = row[y_col], z = row[z_col]), axis=1)
+
+    input_df["allenId"] = input_df.apply(
+        lambda row: annotate_row(x=row[x_col], y=row[y_col], z=row[z_col]),
+        axis=1,
+    )
 
 
-
-def read_swc(input_file, ccf_annotate_vertices, separator=' '):
-    """
-    Will load a ccf-registered swc file 
-
+def read_swc(input_file, ccf_annotate_vertices, separator=" "):
+    """Will load a ccf-registered SWC file, optionally applying an offset to (x,y,z) coordinates if a line in the header has the format: # OFFSET X Y Z
     Args:
-        input_file (str): path to swc file to load
-        separator (str): space separator 
-      
+        input_file (str): Path to SWC file to load.
+        ccf_annotate_vertices (bool): Whether to annotate the vertices with a
+            CCF structure ID.
+        separator (str): Delimiter for the SWC coordinates. Defaults to ' '.
+
     Returns:
-        swc_df: DataFrame  
+        pd.DataFrame: A DataFrame with columns:
+            ['node_id', 'compartment', 'x', 'y', 'z', 'r', 'parent', 'allenId'].
     """
-    # pandas >=0.24 will allow reading directly from cloud locations
-    swc_df = pd.read_csv(input_file,
-                    sep=separator,
-                    comment='#',
-                    header=None,
-                    names=['node_id', 'compartment', 'x', 'y', 'z', 'r', 'parent'])
-    # swc_df.set_index("node_id",inplace=True)
-    if ccf_annotate_vertices:    
-        annotate_ccf_structure(swc_df, x_col='x', y_col='y', z_col='z')
+    # Default offset
+    offset_x = 0.0
+    offset_y = 0.0
+    offset_z = 0.0
+
+    # First pass: read the file line by line to detect if an OFFSET line is present
+    with open(input_file, "r") as f:
+        for line in f:
+            if line.strip().startswith("# OFFSET"):
+                # Expected format: "# OFFSET X Y Z"
+                parts = line.strip().split()
+                # parts[0] = "#", parts[1] = "OFFSET", parts[2] = X, parts[3] = Y, parts[4] = Z
+                if len(parts) == 5:
+                    try:
+                        offset_x = float(parts[2])
+                        offset_y = float(parts[3])
+                        offset_z = float(parts[4])
+                    except ValueError:
+                        raise ValueError(
+                            "Invalid OFFSET line in header. "
+                            "Expected numeric values after '# OFFSET': "
+                            f"{line.strip()}"
+                        )
+                else:
+                    raise ValueError(
+                        "Invalid OFFSET line in SWC header. "
+                        "Expected exactly 3 numbers following '# OFFSET'."
+                    )
+                break  # We only look for the first occurrence of OFFSET.
+
+    # Now read the SWC file as usual, ignoring the header lines (#)
+    swc_df = pd.read_csv(
+        input_file,
+        delim_whitespace=True,
+        comment="#",
+        header=None,
+        names=["node_id", "compartment", "x", "y", "z", "r", "parent"],
+    )
+
+    # Apply the offset to (x, y, z)
+    swc_df["x"] = swc_df["x"] + offset_x
+    swc_df["y"] = swc_df["y"] + offset_y
+    swc_df["z"] = swc_df["z"] + offset_z
+
+    if ccf_annotate_vertices:
+        annotate_ccf_structure(swc_df, x_col="x", y_col="y", z_col="z")
     else:
-        swc_df['allenId']=[0]*len(swc_df)
-        
+        swc_df["allenId"] = [0] * len(swc_df)
+
     return swc_df
 
-        
 
 def read_json(input_file, ccf_annotate_vertices):
     """
     Will load a ccf-registered mouselight json file.
-    
+
     Args:
         input_file (str): path to mouselight json
-        
+
     Returns:
         nrn_df: DataFrame
     """
-    
-    compartments = ['axon','dendrite']
+
+    compartments = ["axon", "dendrite"]
 
     file_content = read_file(input_file)
     data_dict = json.loads(file_content)
-    data_key = 'neurons' if 'neurons' in data_dict else 'neuron'
-    neuron_list = data_dict[data_key] if data_key == 'neurons' else [data_dict[data_key]]
-    
+    data_key = "neurons" if "neurons" in data_dict else "neuron"
+    neuron_list = (
+        data_dict[data_key] if data_key == "neurons" else [data_dict[data_key]]
+    )
+
     # as per validation of the input file, there should be exactly one neuron in neuron_list
     neuron_dict = neuron_list[0]
-        
-    soma = neuron_dict['soma']
-    soma_rad = soma['radius'] if 'radius' in soma else 0
+
+    soma = neuron_dict["soma"]
+    soma_rad = soma["radius"] if "radius" in soma else 0
     soma_struct = 0
-    
+
     # check if cell has node level ccf annotations
     has_ccf_annotations = False
-    if 'allenId' in soma:
-        soma_struct = soma['allenId']
+    if "allenId" in soma:
+        soma_struct = soma["allenId"]
         has_ccf_annotations = True
-        
+
     soma_data = [
         1,
         1,
-        soma['x'],
-        soma['y'],
-        soma['z'],
+        soma["x"],
+        soma["y"],
+        soma["z"],
         soma_rad,
         -1,
-        soma_struct
+        soma_struct,
     ]
 
     this_neuron_node_list = [soma_data]
     node_count = 1
     for node_type_str in compartments:
-        
+
         # dictionary that tracks node ids from the compartment tree level (local)
         # to their ID in the entire neuron tree (global)
-        local_id_to_global_id = {1:1}
-        
+        local_id_to_global_id = {1: 1}
+
         # get list of nodes in this compartment
         if node_type_str in neuron_dict:
             compartment_node_list = neuron_dict[node_type_str]
@@ -177,74 +240,96 @@ def read_json(input_file, ccf_annotate_vertices):
             compartment_node_list = []
 
         # look up tables for parent-child relationships
-        node_id_to_node = { n['sampleNumber'] : n for n in compartment_node_list }
-        parent_ids_dict = { nid: n['parentNumber'] for nid,n in iteritems(node_id_to_node) }
-        child_ids_dict = { nid:[] for nid in node_id_to_node }
+        node_id_to_node = {n["sampleNumber"]: n for n in compartment_node_list}
+        parent_ids_dict = {
+            nid: n["parentNumber"] for nid, n in iteritems(node_id_to_node)
+        }
+        child_ids_dict = {nid: [] for nid in node_id_to_node}
         for nid in parent_ids_dict:
             pid = parent_ids_dict[nid]
             if pid != -1:
                 child_ids_dict[pid].append(nid)
 
         # find root nodes of this compartment tree
-        root_nodes = [n for n in compartment_node_list if n['parentNumber']==-1]
+        root_nodes = [
+            n for n in compartment_node_list if n["parentNumber"] == -1
+        ]
         for root in root_nodes:
-            
-            if [soma['x'], soma['y'], soma['z']] == [root['x'], root['y'], root['z']]:
-                # this root is the same as the soma, 
+
+            if [soma["x"], soma["y"], soma["z"]] == [
+                root["x"],
+                root["y"],
+                root["z"],
+            ]:
+                # this root is the same as the soma,
                 # just append its children to the queue
-                roots_children = [node_id_to_node[i] for i in child_ids_dict[root['sampleNumber']]]
+                roots_children = [
+                    node_id_to_node[i]
+                    for i in child_ids_dict[root["sampleNumber"]]
+                ]
                 this_queue = deque(roots_children)
-                
+
             else:
                 # this is a root that is separate from the soma, therfore begin the
                 # queue with this root
                 this_queue = deque([root])
-            
-            # iterate over this tree with dfs 
+
+            # iterate over this tree with dfs
             while len(this_queue) > 0:
-                
-                node_count+=1
+
+                node_count += 1
                 this_node = this_queue.popleft()
-                
-                
+
                 # get local (within subtree) ID and global ID (across entire neuron)
-                local_id = this_node['sampleNumber']
+                local_id = this_node["sampleNumber"]
                 global_id = node_count
                 local_id_to_global_id[local_id] = global_id
-                
-                local_parent_id = this_node['parentNumber']
-                
+
+                local_parent_id = this_node["parentNumber"]
+
                 if local_parent_id == -1:
                     # this_node is a new root node
-                    global_parent_id = -1 
+                    global_parent_id = -1
                 else:
                     global_parent_id = local_id_to_global_id[local_parent_id]
-                
-                children = [node_id_to_node[i] for i in child_ids_dict[local_id]]
+
+                children = [
+                    node_id_to_node[i] for i in child_ids_dict[local_id]
+                ]
                 for child in children:
                     this_queue.appendleft(child)
-                    
-                node_struct = this_node['allenId'] if 'allenId' in this_node else 0
-                
+
+                node_struct = (
+                    this_node["allenId"] if "allenId" in this_node else 0
+                )
+
                 record = [
-                    global_id, 
-                    this_node['structureIdentifier'],
-                    this_node['x'], 
-                    this_node['y'], 
-                    this_node['z'], 
-                    this_node['radius'],
-                    global_parent_id, 
-                    node_struct
+                    global_id,
+                    this_node["structureIdentifier"],
+                    this_node["x"],
+                    this_node["y"],
+                    this_node["z"],
+                    this_node["radius"],
+                    global_parent_id,
+                    node_struct,
                 ]
-                
+
                 this_neuron_node_list.append(record)
 
-    col_list = ['node_id', 'compartment', 'x', 'y', 'z', 'r', 'parent', 'allenId']
-    nrn_df = pd.DataFrame(this_neuron_node_list, columns = col_list)
+    col_list = [
+        "node_id",
+        "compartment",
+        "x",
+        "y",
+        "z",
+        "r",
+        "parent",
+        "allenId",
+    ]
+    nrn_df = pd.DataFrame(this_neuron_node_list, columns=col_list)
     if not has_ccf_annotations and ccf_annotate_vertices:
-        annotate_ccf_structure(nrn_df, x_col='x', y_col='y', z_col='z')
-    
-            
+        annotate_ccf_structure(nrn_df, x_col="x", y_col="y", z_col="z")
+
     return nrn_df
 
 
@@ -256,9 +341,9 @@ def read_h5(input_file, ccf_annotate_vertices):
         ccf_annotate_vertices (bool): when True will try to annotate the vertices with ccf structure ID
 
     Returns:
-        pd.Datarame: 
+        pd.Datarame:
     """
-       
+
     directory = get_parent_dir(input_file)
     filename = get_basename(input_file)
     if "://" not in directory:
@@ -266,19 +351,24 @@ def read_h5(input_file, ccf_annotate_vertices):
 
     cf = CloudFiles(directory)
     binary = cf.get([filename])
-    with io.BytesIO(cf.get(binary[0]['path'])) as f:
+    with io.BytesIO(cf.get(binary[0]["path"])) as f:
         f.seek(0)
         mw = meshwork.load_meshwork(f)
-    data_df = meshwork_skeleton_to_neurondata(mw, ccf_annotate_vertices, get_compartment_labels=True)
+    data_df = meshwork_skeleton_to_neurondata(
+        mw,
+        ccf_annotate_vertices,
+        get_compartment_labels=True,
+        ccf_annotate_vertices=ccf_annotate_vertices,
+    )
 
     return data_df
 
 
 def read_precomputed(project_directory, skeleton_id, ccf_annotate_vertices):
-    """load a precomputed neuroglancer file into a dataframe. The input project directory should 
+    """load a precomputed neuroglancer file into a dataframe. The input project directory should
     follow the format as seen below:
-    
-    project_directory 
+
+    project_directory
         info
         skeleton
             1324
@@ -306,9 +396,9 @@ def read_precomputed(project_directory, skeleton_id, ccf_annotate_vertices):
 
     edges = skel.edges
 
-    # get compartment labels 
+    # get compartment labels
     skel_attributes = dir(skel)
-    if 'compartment' in skel_attributes:
+    if "compartment" in skel_attributes:
         node_types = skel.compartment
     elif "vertex_types" in skel_attributes:
         node_types = skel.vertex_types
@@ -316,14 +406,14 @@ def read_precomputed(project_directory, skeleton_id, ccf_annotate_vertices):
         node_types = skel.compartments
     else:
         node_types = np.zeros((n_vertices))
-    
+
     # get allen ID
     allen_ids = np.zeros((n_vertices))
     found_allen_ids = False
     if "allenId" in skel_attributes:
         allen_ids = skel.allenId
         found_allen_ids = True
-        
+
     # get presynaptic_count
     pre_syn_ct = np.zeros((n_vertices))
     if "presynaptic_count" in skel_attributes:
@@ -333,40 +423,69 @@ def read_precomputed(project_directory, skeleton_id, ccf_annotate_vertices):
     post_syn_ct = np.zeros((n_vertices))
     if "postsynaptic_count" in skel_attributes:
         post_syn_ct = skel.postsynaptic_count
-        
-    
-    # start building neuron data 
+
+    # start building neuron data
     data_list = [
         vertices,
-        skel.radius.reshape(-1,1),
-        node_types.reshape(-1,1),
-        allen_ids.reshape(-1,1),
-        pre_syn_ct.reshape(-1,1),
-        post_syn_ct.reshape(-1,1),
+        skel.radius.reshape(-1, 1),
+        node_types.reshape(-1, 1),
+        allen_ids.reshape(-1, 1),
+        pre_syn_ct.reshape(-1, 1),
+        post_syn_ct.reshape(-1, 1),
     ]
-    data_arr =  np.hstack(data_list)
-    neuron_df = pd.DataFrame(data_arr, columns = ['x','y','z','r','compartment','allenId','presynaptic_count','postsynaptic_count'])
-    neuron_df['parent'] = [None]*n_vertices
-    neuron_df[['x','y','z']] = neuron_df[['x','y','z']]/1000
-    
+    data_arr = np.hstack(data_list)
+    neuron_df = pd.DataFrame(
+        data_arr,
+        columns=[
+            "x",
+            "y",
+            "z",
+            "r",
+            "compartment",
+            "allenId",
+            "presynaptic_count",
+            "postsynaptic_count",
+        ],
+    )
+    neuron_df["parent"] = [None] * n_vertices
+    neuron_df[["x", "y", "z"]] = neuron_df[["x", "y", "z"]] / 1000
+
     for edge in edges:
-        neuron_df.loc[edge[0],'parent'] = edge[1]
+        neuron_df.loc[edge[0], "parent"] = edge[1]
 
     # the root index will be the one that is not in the edge IDs
-    root_index = set(np.arange(n_vertices)) - set(edges[:,0])
-    neuron_df.loc[root_index, 'parent'] = -2
-    neuron_df['node_id'] = neuron_df.index
-    neuron_df['node_id'] = neuron_df['node_id']+1
-    neuron_df['parent'] = neuron_df['parent']+1
-    
-    neuron_df = neuron_df[['node_id','compartment','x','y','z','r','parent','allenId','presynaptic_count','postsynaptic_count']]
-    
+    root_index = set(np.arange(n_vertices)) - set(edges[:, 0])
+    neuron_df.loc[root_index, "parent"] = -2
+    neuron_df["node_id"] = neuron_df.index
+    neuron_df["node_id"] = neuron_df["node_id"] + 1
+    neuron_df["parent"] = neuron_df["parent"] + 1
+
+    neuron_df = neuron_df[
+        [
+            "node_id",
+            "compartment",
+            "x",
+            "y",
+            "z",
+            "r",
+            "parent",
+            "allenId",
+            "presynaptic_count",
+            "postsynaptic_count",
+        ]
+    ]
+
     if ccf_annotate_vertices and not found_allen_ids:
-        annotate_ccf_structure(neuron_df, x_col='x', y_col='y', z_col='z')
-        
+        annotate_ccf_structure(neuron_df, x_col="x", y_col="y", z_col="z")
+
     return neuron_df
 
-def meshwork_skeleton_to_neurondata(mw, ccf_annotate_vertices, get_compartment_labels):
+
+def meshwork_skeleton_to_neurondata(
+    mw,
+    ccf_annotate_vertices,
+    get_compartment_labels,
+):
     """
     Will convert a meshwork object to a NeuronData object
 
@@ -386,64 +505,98 @@ def meshwork_skeleton_to_neurondata(mw, ccf_annotate_vertices, get_compartment_l
     edges = mw.skeleton.edges
     root_index = mw.skeleton._rooted.root
 
-    r_df = mw.anno.segment_properties.df[['r_eff', 'mesh_ind_filt']].set_index('mesh_ind_filt')
-    radius = r_df.loc[mw.skeleton_indices.to_mesh_region_point].r_eff.values / 1000
+    r_df = mw.anno.segment_properties.df[["r_eff", "mesh_ind_filt"]].set_index(
+        "mesh_ind_filt"
+    )
+    radius = (
+        r_df.loc[mw.skeleton_indices.to_mesh_region_point].r_eff.values / 1000
+    )
 
     # get compartment labels
     if get_compartment_labels:
-        compartment = pull_mw_skel_colors(mw, 'basal_mesh_labels', 'is_axon', 'apical_mesh_labels')
+        compartment = pull_mw_skel_colors(
+            mw, "basal_mesh_labels", "is_axon", "apical_mesh_labels"
+        )
     else:
         compartment = np.zeros(len(radius))
 
     # start building neuron data
-    data_list = [
-        vertices,
-        radius.reshape(-1, 1),
-        compartment.reshape(-1, 1)
-    ]
+    data_list = [vertices, radius.reshape(-1, 1), compartment.reshape(-1, 1)]
     data_arr = np.hstack(data_list)
 
-    neuron_df = pd.DataFrame(data_arr, columns=['x', 'y', 'z', 'r', 'compartment'])
-    neuron_df['parent'] = [None] * n_vertices
+    neuron_df = pd.DataFrame(
+        data_arr, columns=["x", "y", "z", "r", "compartment"]
+    )
+    neuron_df["parent"] = [None] * n_vertices
 
     for edge in edges:
-        neuron_df.loc[edge[0], 'parent'] = edge[1]
-    neuron_df.loc[root_index, 'parent'] = -2
-    neuron_df['node_id'] = neuron_df.index
-    neuron_df['node_id'] = neuron_df['node_id'] + 1
-    neuron_df['parent'] = neuron_df['parent'] + 1
+        neuron_df.loc[edge[0], "parent"] = edge[1]
+    neuron_df.loc[root_index, "parent"] = -2
+    neuron_df["node_id"] = neuron_df.index
+    neuron_df["node_id"] = neuron_df["node_id"] + 1
+    neuron_df["parent"] = neuron_df["parent"] + 1
 
     # Quantify synapses by node
-    postsyn_counts_df = pd.DataFrame(mw.anno.post_syn.df['post_pt_mesh_ind_filt'].value_counts())
-    postsyn_counts_df.columns = ['count']
-    postsyn_counts_df.index.names = ['mesh']
+    postsyn_counts_df = pd.DataFrame(
+        mw.anno.post_syn.df["post_pt_mesh_ind_filt"].value_counts()
+    )
+    postsyn_counts_df.columns = ["count"]
+    postsyn_counts_df.index.names = ["mesh"]
 
-    postsyn_mesh = pd.DataFrame(mw.mesh_indices.to_skel_index_padded, columns=['skel'])
-    postsyn_mesh.index.names = ['mesh']
-    postsyn_mesh['counts'] = 0
-    postsyn_mesh.loc[postsyn_counts_df.index, 'counts'] = postsyn_counts_df['count']
+    postsyn_mesh = pd.DataFrame(
+        mw.mesh_indices.to_skel_index_padded, columns=["skel"]
+    )
+    postsyn_mesh.index.names = ["mesh"]
+    postsyn_mesh["counts"] = 0
+    postsyn_mesh.loc[postsyn_counts_df.index, "counts"] = postsyn_counts_df[
+        "count"
+    ]
 
-    presyn_counts_df = pd.DataFrame(mw.anno.pre_syn.df['pre_pt_mesh_ind_filt'].value_counts())
-    presyn_counts_df.columns = ['count']
-    presyn_counts_df.index.names = ['mesh']
+    presyn_counts_df = pd.DataFrame(
+        mw.anno.pre_syn.df["pre_pt_mesh_ind_filt"].value_counts()
+    )
+    presyn_counts_df.columns = ["count"]
+    presyn_counts_df.index.names = ["mesh"]
 
-    presyn_mesh = pd.DataFrame(mw.mesh_indices.to_skel_index_padded, columns=['skel'])
-    presyn_mesh.index.names = ['mesh']
-    presyn_mesh['counts'] = 0
-    presyn_mesh.loc[presyn_counts_df.index, 'counts'] = presyn_counts_df['count']
+    presyn_mesh = pd.DataFrame(
+        mw.mesh_indices.to_skel_index_padded, columns=["skel"]
+    )
+    presyn_mesh.index.names = ["mesh"]
+    presyn_mesh["counts"] = 0
+    presyn_mesh.loc[presyn_counts_df.index, "counts"] = presyn_counts_df[
+        "count"
+    ]
 
-    postsyn_skel_counts = postsyn_mesh.groupby('skel').sum().to_dict()['counts']
-    presyn_skel_counts = presyn_mesh.groupby('skel').sum().to_dict()['counts']
+    postsyn_skel_counts = (
+        postsyn_mesh.groupby("skel").sum().to_dict()["counts"]
+    )
+    presyn_skel_counts = presyn_mesh.groupby("skel").sum().to_dict()["counts"]
 
-    neuron_df['postsynaptic_count'] = neuron_df['node_id'].map(postsyn_skel_counts)
-    neuron_df['presynaptic_count'] = neuron_df['node_id'].map(presyn_skel_counts)
+    neuron_df["postsynaptic_count"] = neuron_df["node_id"].map(
+        postsyn_skel_counts
+    )
+    neuron_df["presynaptic_count"] = neuron_df["node_id"].map(
+        presyn_skel_counts
+    )
     if ccf_annotate_vertices:
-        io.annotate_ccf_structure(neuron_df, x_col='x', y_col='y', z_col='z')
+        annotate_ccf_structure(neuron_df, x_col="x", y_col="y", z_col="z")
     else:
-        neuron_df['allenId'] = [0] * len(neuron_df)
+        neuron_df["allenId"] = [0] * len(neuron_df)
 
     neuron_df = neuron_df[
-        ['node_id', 'compartment', 'x', 'y', 'z', 'r', 'parent', 'allenId', 'presynaptic_count', 'postsynaptic_count']]
+        [
+            "node_id",
+            "compartment",
+            "x",
+            "y",
+            "z",
+            "r",
+            "parent",
+            "allenId",
+            "presynaptic_count",
+            "postsynaptic_count",
+        ]
+    ]
 
     neuron_data = NeuronData(input_data=neuron_df, ccf_annotate_vertices=False)
 

--- a/src/aind_neuron_reconstruction_io/utils.py
+++ b/src/aind_neuron_reconstruction_io/utils.py
@@ -1,0 +1,299 @@
+import numpy as np 
+import os
+import boto3
+from botocore.exceptions import NoCredentialsError, ClientError
+from google.cloud import storage
+from urllib.parse import urlparse
+
+
+def coordinates_to_voxels(coords, resolution=(10, 10, 10)):
+    """ Find the voxel coordinates of spatial coordinates
+
+    Parameters
+    ----------
+    coords : array
+        (n, m) coordinate array. m must match the length of `resolution`
+    resolution : tuple, default (10, 10, 10)
+        Size of voxels in each dimension
+
+    Returns
+    -------
+    voxels : array
+        Integer voxel coordinates corresponding to `coords`
+    """
+
+    if len(resolution) != coords.shape[1]:
+        raise ValueError(
+            f"second dimension of `coords` must match length of `resolution`; "
+            f"{len(resolution)} != {coords.shape[1]}")
+
+    if not np.issubdtype(coords.dtype, np.number):
+        raise ValueError(f"coords must have a numeric dtype (dtype is '{coords.dtype}')")
+
+    voxels = np.floor(coords / resolution).astype(int)
+    return voxels
+
+
+def fix_local_cloudpath(cloudpath):
+    """
+    Ensure cloud path formatting.
+
+    Args:
+        cloudpath (str): Path to file or directory.
+
+    Returns:
+        str: Fixed cloud path.
+    """
+    if "://" not in cloudpath:
+        dir, _ = os.path.split(cloudpath)
+        if len(dir) == 0:
+            cloudpath = "./" + cloudpath
+        cloudpath = "file://" + cloudpath
+    return cloudpath
+
+
+def file_exists(path):
+    """
+    Check if file exists in local or cloud storage.
+
+    Args:
+        path (str): File path.
+
+    Returns:
+        bool: True if file exists, False otherwise.
+    """
+    if path.startswith("s3://"):
+        return s3_file_exists(path)
+    elif path.startswith("gs://"):
+        return gcs_file_exists(path)
+    else:
+        return os.path.exists(path)
+
+
+def s3_file_exists(path):
+    """
+    Check if file exists in Amazon S3.
+
+    Args:
+        path (str): S3 file path.
+
+    Returns:
+        bool: True if file exists, False otherwise.
+    """
+    parsed_url = urlparse(path)
+    bucket_name = parsed_url.netloc
+    file_key = parsed_url.path.lstrip('/')
+    s3 = boto3.client('s3')
+    try:
+        s3.head_object(Bucket=bucket_name, Key=file_key)
+        return True
+    except NoCredentialsError:
+        raise ValueError("AWS credentials not found.")
+    except ClientError:
+        return False
+
+
+def gcs_file_exists(path):
+    """
+    Check if file exists in Google Cloud Storage.
+
+    Args:
+        path (str): GCS file path.
+
+    Returns:
+        bool: True if file exists, False otherwise.
+    """
+    parsed_url = urlparse(path)
+    bucket_name = parsed_url.netloc
+    file_key = parsed_url.path.lstrip('/')
+    client = storage.Client()
+    bucket = client.bucket(bucket_name)
+    blob = bucket.blob(file_key)
+    return blob.exists()
+
+
+def get_parent_dir(path):
+    """
+    Get parent directory of a file or directory path.
+
+    Args:
+        path (str): File or directory path.
+
+    Returns:
+        str: Parent directory path.
+    """
+    if path.startswith("s3://") or path.startswith("gs://"):
+        parsed_url = urlparse(path)
+        parent_dir = '/'.join(parsed_url.path.strip('/').split('/')[:-1])
+        return f"{parsed_url.scheme}://{parsed_url.netloc}/{parent_dir}"
+    else:
+        return os.path.dirname(path)
+
+
+def get_grandparent_dir(path):
+    """
+    Get grandparent directory of a file or directory path.
+
+    Args:
+        path (str): File or directory path.
+
+    Returns:
+        str: Grandparent directory path.
+    """
+    if path.startswith("s3://") or path.startswith("gs://"):
+        parsed_url = urlparse(path)
+        grandparent_dir = '/'.join(parsed_url.path.strip('/').split('/')[:-2])
+        return f"{parsed_url.scheme}://{parsed_url.netloc}/{grandparent_dir}"
+    else:
+        return os.path.dirname(os.path.dirname(path))
+
+
+def get_basename(path):
+    """
+    Get basename of a file path.
+
+    Args:
+        path (str): File path.
+
+    Returns:
+        str: Basename of the file.
+    """
+    if path.startswith("s3://") or path.startswith("gs://"):
+        parsed_url = urlparse(path)
+        return os.path.basename(parsed_url.path)
+    else:
+        return os.path.basename(path)
+
+
+def get_file_extension(path):
+    """
+    Get file extension.
+
+    Args:
+        path (str): File path.
+
+    Returns:
+        str: File extension.
+    """
+    if path.startswith("s3://") or path.startswith("gs://"):
+        return os.path.splitext(urlparse(path).path)[1]
+    else:
+        return os.path.splitext(path)[1]
+
+
+def create_directory(path):
+    """
+    Create directory in local or cloud storage.
+
+    Args:
+        path (str): Directory path.
+    """
+    if path.startswith("s3://"):
+        s3_create_directory(path)
+    elif path.startswith("gs://"):
+        gcs_create_directory(path)
+    else:
+        os.makedirs(path, exist_ok=True)
+
+
+def s3_create_directory(path):
+    """
+    Create directory in Amazon S3.
+
+    Args:
+        path (str): S3 directory path.
+    """
+    parsed_url = urlparse(path)
+    bucket_name = parsed_url.netloc
+    directory_key = parsed_url.path.lstrip('/') + '/'
+    s3 = boto3.client('s3')
+    try:
+        s3.put_object(Bucket=bucket_name, Key=directory_key)
+    except NoCredentialsError:
+        raise ValueError("AWS credentials not found.")
+    except ClientError as e:
+        raise ValueError(f"Failed to create directory in S3: {e}")
+
+
+def gcs_create_directory(path):
+    """
+    Create directory in Google Cloud Storage.
+
+    Args:
+        path (str): GCS directory path.
+    """
+    parsed_url = urlparse(path)
+    bucket_name = parsed_url.netloc
+    directory_key = parsed_url.path.lstrip('/') + '/'
+    client = storage.Client()
+    bucket = client.bucket(bucket_name)
+    blob = bucket.blob(directory_key)
+    try:
+        blob.upload_from_string('')
+    except Exception as e:
+        raise ValueError(f"Failed to create directory in GCS: {e}")
+
+def read_file(path_to_file):
+    """
+    Read a file from local filesystem, GCS, or S3.
+    Args:
+        path_to_file (str): The path to the file.
+    Returns:
+        str: The content of the file as a string.
+    """
+    if path_to_file.startswith("s3://"):
+        return read_s3_file(path_to_file)
+    elif path_to_file.startswith("gs://"):
+        return read_gcs_file(path_to_file)
+    else:
+        return read_local_file(path_to_file)
+
+def read_local_file(path_to_file):
+    """
+    Read a local file.
+    Args:
+        path_to_file (str): The path to the local file.
+    Returns:
+        str: The content of the file as a string.
+    """
+    with open(path_to_file, 'r') as file:
+        return file.read()
+
+def read_gcs_file(path_to_file):
+    """
+    Read a file from Google Cloud Storage.
+    Args:
+        path_to_file (str): The path to the GCS file.
+    Returns:
+        str: The content of the file as a string.
+    """
+    parsed_url = urlparse(path_to_file)
+    bucket_name = parsed_url.netloc
+    file_key = parsed_url.path.lstrip('/')
+    
+    client = storage.Client()
+    bucket = client.bucket(bucket_name)
+    blob = bucket.blob(file_key)
+    
+    return blob.download_as_text()
+
+def read_s3_file(path_to_file):
+    """
+    Read a file from Amazon S3.
+    Args:
+        path_to_file (str): The path to the S3 file.
+    Returns:
+        str: The content of the file as a string.
+    """
+    parsed_url = urlparse(path_to_file)
+    bucket_name = parsed_url.netloc
+    file_key = parsed_url.path.lstrip('/')
+    
+    s3 = boto3.client('s3')
+    try:
+        obj = s3.get_object(Bucket=bucket_name, Key=file_key)
+        return obj['Body'].read().decode('utf-8')
+    except NoCredentialsError:
+        raise ValueError("AWS credentials not found.")
+    except s3.exceptions.NoSuchKey:
+        raise FileNotFoundError(f"File not found: {path_to_file}")

--- a/src/aind_neuron_reconstruction_io/utils.py
+++ b/src/aind_neuron_reconstruction_io/utils.py
@@ -297,3 +297,30 @@ def read_s3_file(path_to_file):
         raise ValueError("AWS credentials not found.")
     except s3.exceptions.NoSuchKey:
         raise FileNotFoundError(f"File not found: {path_to_file}")
+
+
+def pull_mw_skel_colors(mw, basal_table, axon_table, apical_table):
+    ''' pulls the segment properties from meshwork anno and translates into skel index
+    basal node table used for general dendrite labels if no apical/basal differentiation
+    apical_table is optional 
+    '''
+    node_labels = np.full(len(mw.skeleton.vertices), 0)
+    soma_node = mw.skeleton.root
+    
+    basal_nodes = mw.anno[basal_table].skel_index
+    node_labels[basal_nodes] = 3
+
+    node_labels[soma_node] = 1
+
+    axon_nodes = mw.anno[axon_table].skel_index
+
+    if apical_table is not None:
+        apical_nodes = mw.anno[apical_table].skel_index
+        node_labels[apical_nodes] = 4            
+    
+    node_labels[axon_nodes] = 2
+
+    if 0 in node_labels:
+        print("Warning: label annotations passed give labels that are shorter than total length of skeleton nodes to label. Unassigned nodes have been labeled 0. if using pull_compartment_colors, add an option for 0 in inskel_color_map such as skel_color_map={3: 'firebrick', 4: 'salmon', 2: 'steelblue', 1: 'olive', 0:'gray'}.")
+
+    return node_labels


### PR DESCRIPTION
This is the first iteration of a repository designed to load skeleton data of various types (.swc, mouselight .json, .h5) from multiple sources (local, Google Cloud, S3) into a unified data structure (NeuronData). This structure can be written to precomputed files for Neuroglancer integration. Additionally, this repository includes code to convert meshparty meshwork objects to NeuronData objects. All NeuronData objects have the following metadata parameters for each vertex:

- allenId (the allen ccf ID for each vertex, if applicable otherwise 0)
- presynaptic_count (pre synaptic connection count for each vertex)
- postsynaptic_count (post synaptic connection count for each vertex)


Some priority issues to be addressed are detailed below and will be tracked in the repo 'Issues' section.

1. Change parent class of NeuronData from pandas dataframe to meshparty meshwork. Dataframe was chosen because at first, the scope of this project was handling ccf registered .swc and .json files and pandas served as a lightweight/minimal dependency. However, since compatibility with EM data (.h5 and meshwork objects) was added, meshparty is now a dependency. Additionally, when converting a meshwork object to precomputed, currently this repo performs meshwork -> NeuronData -> precomputed which could be consolidated if the parent class of NeuronData was a meshwork object.

2. Create a more flexible framework for metadata. Right now, vertex level metadata as described above is calculated because those were the explicit and immediate needs of the repo. However, a framework for flexible metadata addition is needed. This would allow further additions of user specified metadata at the vertex level (e.g. myelination) or cell level (e.g. soma location, # of tip nodes etc.). 

3. Flexibility to write a NeuronData object to: mouselight .json, .swc, .h5
 